### PR TITLE
Allow nested rerun calls to run from an archive

### DIFF
--- a/modules/stubbs/templates/launcher
+++ b/modules/stubbs/templates/launcher
@@ -27,6 +27,9 @@ export RERUN_MODULES=$PAYLOAD/rerun/modules
 # move into the current working directory
 cd $CWD || die "couldn't change to current working directory: $CWD"
 
+# add archive rerun script to path
+PATH=$PATH:$PAYLOAD/rerun
+
 # launch it!
 exec $PAYLOAD/rerun/rerun "$@"
 


### PR DESCRIPTION
This change should allow nested rerun calls to run in exploded and archived formats
