### PR TITLE
Allow RERUN_MODULES to have multiple entries, like $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For command line syntax and example usage execute `rerun` using the `--help` fla
 	| '__/ _ \ '__| | | | '_ \ 
 	| | |  __/ |  | |_| | | | |
 	|_|  \___|_|   \__,_|_| |_|
-	Version: 1.3.5. License: Apache 2.0.
+	Version: 1.3.6. License: Apache 2.0.
 
 	Usage: rerun [-h][-v][-V] [-M <dir>] [module:[command [options]]]
 
@@ -125,7 +125,7 @@ The "false" is the default value assigned to the "--overwrite" option.
 
 See the "Environment" section below to learn about the
 `RERUN_MODULES` environment variable. This variable
-specifies the directory where rerun modules exist.
+specifies the directory/ies where rerun modules exist.
 
 ### Bash completion
 
@@ -182,7 +182,7 @@ would be:
 
     $ rerun -M /var/rerun stubbs:archive
 
-You can also declare the `RERUN_MODULES` environment variable to sepcify the modules directory.
+You can also declare the `RERUN_MODULES` environment variable to sepcify the modules directory path.
 
 ### Archives
 
@@ -471,9 +471,10 @@ The user would see the following message on the console:
 # ENVIRONMENT
 
 `RERUN_MODULES`
-: Path to directory containing rerun modules.
+: Path to directories containing rerun modules.
 If RERUN_MODULES is not set, it is defaulted
 relative to the location of the rerun executable.
+Multiple directories can be specified separated by a ':' (like $PATH).
 
 `RERUN_COLOR`
 : Set 'true' if you want ANSI text effects. Makes

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([rerun], [1.3.5], [rerun-discuss@googlegroups.com],
+AC_INIT([rerun], [1.3.6], [rerun-discuss@googlegroups.com],
              [rerun], [https://github.com/rerun/rerun/wiki])
 
 dnl Created by stagr.lee@gmail.com, 27SEP11

--- a/modules/stubbs/commands/add-command/script
+++ b/modules/stubbs/commands/add-command/script
@@ -105,13 +105,15 @@ STUB=$RERUN_MODULE_DIR/lib/stub/bash
 
 OPTIONS_SCRIPT=$(rerun_property_get $STUB OPTIONS_SCRIPT)
 
-OPTIONS_PARSER_SCRIPT=$RERUN_MODULES/$MODULE/commands/$COMMAND/$OPTIONS_SCRIPT
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+
+OPTIONS_PARSER_SCRIPT=$RERUN_MODULE_HOME_DIR/commands/$COMMAND/$OPTIONS_SCRIPT
 
 
 # Create command structure
-mkdir -p $RERUN_MODULES/$MODULE/commands/$COMMAND || rerun_die "Failed creating command structure"
+mkdir -p $RERUN_MODULE_HOME_DIR/commands/$COMMAND || rerun_die "Failed creating command structure"
 
-VARIABLES=$(stubbs_option_variables $RERUN_MODULES/$MODULE $COMMAND)
+VARIABLES=$(stubbs_option_variables $RERUN_MODULE_HOME_DIR $COMMAND)
 
 TEMPLATE_COMMAND_SCRIPT=$(rerun_property_get $STUB TEMPLATE_COMMAND_SCRIPT)
 
@@ -121,7 +123,7 @@ TEMPLATE=$STUB/$TEMPLATE_COMMAND_SCRIPT
 }
 
 
-CMD_SCRIPT=$RERUN_MODULES/$MODULE/commands/$COMMAND/$(basename $TEMPLATE_COMMAND_SCRIPT)
+CMD_SCRIPT=$RERUN_MODULE_HOME_DIR/commands/$COMMAND/$(basename $TEMPLATE_COMMAND_SCRIPT)
 
 # Generate a boiler plate implementation
 [ ! -f $CMD_SCRIPT -o -n "${OVERWRITE:-}" ] && {
@@ -135,18 +137,18 @@ CMD_SCRIPT=$RERUN_MODULES/$MODULE/commands/$COMMAND/$(basename $TEMPLATE_COMMAND
 chmod +x $CMD_SCRIPT || rerun_die "Failed settng execute bit on command script."
 
 # Generate a unit test script
-mkdir -p $RERUN_MODULES/$MODULE/tests || rerun_die "failed creating tests directory"
-[ ! -f $RERUN_MODULES/$MODULE/tests/$COMMAND-1-test.sh -o -n "${OVERWRITE:-}" ] && {
+mkdir -p $RERUN_MODULE_HOME_DIR/tests || rerun_die "failed creating tests directory"
+[ ! -f $RERUN_MODULE_HOME_DIR/tests/$COMMAND-1-test.sh -o -n "${OVERWRITE:-}" ] && {
     sed -e "s/@MODULE@/$MODULE/g" \
 	-e "s/@COMMAND@/$COMMAND/g" \
 	-e "s;@RERUN@;${RERUN};g" \
 	-e "s;@RERUN_MODULES@;${RERUN_MODULES};g" \
-	$RERUN_MODULE_DIR/templates/test.roundup > $RERUN_MODULES/$MODULE/tests/$COMMAND-1-test.sh || rerun_die
-    rerun_log info "Wrote test script: $RERUN_MODULES/$MODULE/tests/$COMMAND-1-test.sh"
+	$RERUN_MODULE_DIR/templates/test.roundup > $RERUN_MODULE_HOME_DIR/tests/$COMMAND-1-test.sh || rerun_die
+    rerun_log info "Wrote test script: $RERUN_MODULE_HOME_DIR/tests/$COMMAND-1-test.sh"
 }
-[ ! -f $RERUN_MODULES/$MODULE/tests/functions.sh -o -n "${OVERWRITE:-}" ] && {
+[ ! -f $RERUN_MODULE_HOME_DIR/tests/functions.sh -o -n "${OVERWRITE:-}" ] && {
     sed -e "s/@MODULE@/$MODULE/g" \
-	$RERUN_MODULE_DIR/templates/test.functions.sh > $RERUN_MODULES/$MODULE/tests/functions.sh || rerun_die "Failed generating test functions library."
+	$RERUN_MODULE_DIR/templates/test.functions.sh > $RERUN_MODULE_HOME_DIR/tests/functions.sh || rerun_die "Failed generating test functions library."
 }
 
 # Generate command metadata
@@ -160,7 +162,7 @@ DESCRIPTION="$DESCRIPTION"
 OPTIONS=
 EOF
 
-) > $RERUN_MODULES/$MODULE/commands/$COMMAND/metadata || rerun_die "Failed creating command metadata."
+) > $RERUN_MODULE_HOME_DIR/commands/$COMMAND/metadata || rerun_die "Failed creating command metadata."
 
 
 # Done.

--- a/modules/stubbs/commands/add-module/script
+++ b/modules/stubbs/commands/add-module/script
@@ -96,11 +96,13 @@ COMMAND_SHELL=$(rerun_property_get $STUB COMMAND_SHELL)
 
 # Create module structure
 
-mkdir -p $RERUN_MODULES/$MODULE || rerun_die "Failed creating module structure."
+RERUN_MODULE_HOME_DIR=$(echo "$RERUN_MODULES" | cut -d: -f1)/$MODULE
+
+mkdir -p $RERUN_MODULE_HOME_DIR || rerun_die "Failed creating module structure."
 # Create commands/ subdirectory
-mkdir -p $RERUN_MODULES/$MODULE/commands || rerun_die "Failed creating module structure."
+mkdir -p $RERUN_MODULE_HOME_DIR/commands || rerun_die "Failed creating module structure."
 # Create lib/ subdirectory
-mkdir -p $RERUN_MODULES/$MODULE/lib || rerun_die "Failed creating module structure."
+mkdir -p $RERUN_MODULE_HOME_DIR/lib || rerun_die "Failed creating module structure."
 
 # Generate a profile for metadata
 (
@@ -115,7 +117,7 @@ REQUIRES=
 EXTERNALS=
 LICENSE=
 EOF
-) > $RERUN_MODULES/$MODULE/metadata || rerun_die "Failed generating metadata."
+) > $RERUN_MODULE_HOME_DIR/metadata || rerun_die "Failed generating metadata."
 
 # Give it the beginnings of a function library.
 # Replace the word "@MODULE@" with the module's given name.
@@ -123,7 +125,7 @@ sed -e "s/@MODULE@/$MODULE/g" \
 	-e "s^@DESCRIPTION@^$DESCRIPTION^g" \
 	-e "s,@SHELL@,$COMMAND_SHELL,g" \
     "$STUB/$TEMPLATE_FUNCTION_LIB" \
-    > "$RERUN_MODULES/$MODULE/lib/$(basename $TEMPLATE_FUNCTION_LIB)" || {
+    > "$RERUN_MODULE_HOME_DIR/lib/$(basename $TEMPLATE_FUNCTION_LIB)" || {
     rerun_die "Failed creating function library for \"$MODULE\"."
 }
 
@@ -133,11 +135,11 @@ if [[ -n "${TEMPLATE:-}" ]]
 then
     if [[ "$TEMPLATE" =~ [/]+ ]]
     then TEMPLATE_DIR=$(rerun_path_absolute $TEMPLATE)
-    else TEMPLATE_DIR=$RERUN_MODULES/$TEMPLATE
+    else TEMPLATE_DIR=$(rerun_module_exists $TEMPLATE)
     fi
     rerun_log info "Copying files from template: $TEMPLATE..."
-    stubbs_module_clone $RERUN_MODULES/$MODULE $TEMPLATE_DIR
+    stubbs_module_clone $RERUN_MODULE_HOME_DIR $TEMPLATE_DIR
 fi
 
 # Done
-rerun_log info "Created module structure: $RERUN_MODULES/$MODULE."
+rerun_log info "Created module structure: $RERUN_MODULE_HOME_DIR."

--- a/modules/stubbs/commands/add-option/script
+++ b/modules/stubbs/commands/add-option/script
@@ -143,8 +143,10 @@ done
     done
 }
 
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+
 # check the chosen module exists
-[[ ! -f $RERUN_MODULES/$MODULE/metadata ]] && rerun_option_error "module not found: $MODULE"
+[[ ! -f $RERUN_MODULE_HOME_DIR/metadata ]] && rerun_option_error "module not found: $MODULE"
 
 [[ -z "${COMMAND:-}" ]] && {
     commands=( $(rerun_commands $RERUN_MODULES $MODULE) )
@@ -168,15 +170,15 @@ done
 
 # This option might already be declared.
 # Confirm the option declaration settings.
-if [[ -f $RERUN_MODULES/$MODULE/options/$OPTION/metadata ]]
+if [[ -f $RERUN_MODULE_HOME_DIR/options/$OPTION/metadata ]]
 then
-    CURR_DESC=$(rerun_property_get $RERUN_MODULES/$MODULE/options/$OPTION DESCRIPTION)
-    CURR_REQ=$(rerun_property_get $RERUN_MODULES/$MODULE/options/$OPTION REQUIRED)
-    CURR_EXPORT=$(rerun_property_get $RERUN_MODULES/$MODULE/options/$OPTION EXPORT) || CURR_EXPORT=false
+    CURR_DESC=$(rerun_property_get $RERUN_MODULE_HOME_DIR/options/$OPTION DESCRIPTION)
+    CURR_REQ=$(rerun_property_get $RERUN_MODULE_HOME_DIR/options/$OPTION REQUIRED)
+    CURR_EXPORT=$(rerun_property_get $RERUN_MODULE_HOME_DIR/options/$OPTION EXPORT) || CURR_EXPORT=false
     # Crap hack to avoid quote stripping or eval expansions. 
     # Use awk to parse the property values.
     CURR_DEFAULT=$(awk -F= '/DEFAULT/ {print $2}' \
-        $RERUN_MODULES/$MODULE/options/$OPTION/metadata)
+        $RERUN_MODULE_HOME_DIR/options/$OPTION/metadata)
 fi
 # Confirm the description.
 [ -z "${DESCRIPTION:-}" ] && {
@@ -210,14 +212,14 @@ fi
 
 # If short is specified, check it's not already used.
 [ -n "${SHORT:-}" ] && {
-    options=$(stubbs_options_with_short "$RERUN_MODULES/$MODULE" $SHORT)
+    options=$(stubbs_options_with_short "$RERUN_MODULE_HOME_DIR" $SHORT)
     [[ -n "${options:-}" && "$options" != $OPTION ]] && {
         rerun_die "-${SHORT} already used by option: $options"
     }
 }
 
 # Generate metadata for new option
-mkdir -p  $RERUN_MODULES/$MODULE/options/$OPTION
+mkdir -p  $RERUN_MODULE_HOME_DIR/options/$OPTION
 (
     cat <<EOF
 # option metadata
@@ -233,10 +235,10 @@ DEFAULT=$(quote_if_whitespace_string $DEFAULT)
 EXPORT=$EXPORT
 
 EOF
-) > $RERUN_MODULES/$MODULE/options/$OPTION/metadata || {
+) > $RERUN_MODULE_HOME_DIR/options/$OPTION/metadata || {
     rerun_die "Failed generating $OPTION option metadata"
 }
-rerun_log info "Wrote option metadata: $RERUN_MODULES/$MODULE/options/$OPTION/metadata"
+rerun_log info "Wrote option metadata: $RERUN_MODULE_HOME_DIR/options/$OPTION/metadata"
 
 COMMAND_LIST=( ${COMMAND//,/ } )
 for cmd in ${COMMAND_LIST[*]}
@@ -244,7 +246,7 @@ do
     #
     # Verify this command exists
     #
-    [ ! -d $RERUN_MODULES/$MODULE/commands/$cmd ] && {
+    [ ! -d $RERUN_MODULE_HOME_DIR/commands/$cmd ] && {
         echo >&2 "command not found: \"$MODULE:$cmd\".... skipping."
         continue
     }
@@ -259,9 +261,9 @@ do
         else command_options=( ${command_options[*]} $OPTION )
         fi
     }
-    command_metadata=$RERUN_MODULES/$MODULE/commands/$cmd/metadata
+    command_metadata=$RERUN_MODULE_HOME_DIR/commands/$cmd/metadata
     stubbs_command_options_write \
-        $RERUN_MODULES/$MODULE $cmd \
+        $RERUN_MODULE_HOME_DIR $cmd \
         "${command_options[*]}" || rerun_die "Failed generating command metadata"
     rerun_log info "Updated command metadata:  $command_metadata"
     #
@@ -276,9 +278,9 @@ do
     [ -z "$OPTIONS_SCRIPT" ] && {
        rerun_die "required metadata not found: OPTIONS_SCRIPT"
     }
-    options_parser=$RERUN_MODULES/$MODULE/commands/$cmd/$OPTIONS_SCRIPT
+    options_parser=$RERUN_MODULE_HOME_DIR/commands/$cmd/$OPTIONS_SCRIPT
     $RERUN_MODULE_DIR/lib/stub/bash/$OPTIONS_GENERATOR \
-        $RERUN_MODULES $MODULE $cmd > $options_parser || {
+        $(dirname $RERUN_MODULE_HOME_DIR) $MODULE $cmd > $options_parser || {
         rerun_die "Failed generating options parser."
     }
     #
@@ -287,11 +289,11 @@ do
     [ -z "$TEMPLATE_COMMAND_SCRIPT" ] && {
         rerun_die "required metadata not found: TEMPLATE_COMMAND_SCRIPT"
     }
-    command_script=$RERUN_MODULES/$MODULE/commands/$cmd/$(basename $TEMPLATE_COMMAND_SCRIPT)
+    command_script=$RERUN_MODULE_HOME_DIR/commands/$cmd/$(basename $TEMPLATE_COMMAND_SCRIPT)
     if [ -f "$command_script" ]
     then
         stubbs_script_header \
-            $RERUN_MODULES/$MODULE $cmd > ${command_script}.$$ || {
+            $RERUN_MODULE_HOME_DIR $cmd > ${command_script}.$$ || {
             rerun_die "Error updating command script header"
         }
         mv $command_script.$$ $command_script || {

--- a/modules/stubbs/commands/archive/script
+++ b/modules/stubbs/commands/archive/script
@@ -123,10 +123,11 @@ build_sh_archive() {
   mkdir -p $PAYLOAD/rerun/modules
   for module in $MODULES
   do
+      rerun_module_home_dir=$(rerun_module_exists $module)
       # Check for a commands subdir to be sure it looks like a module
-      if [ -d ${RERUN_MODULES}/${module}/commands ]
+      if [ -d $rerun_module_home_dir/commands ]
       then
-        pushd ${RERUN_MODULES} > /dev/null
+        pushd $rerun_module_home_dir/.. /dev/null
         tar -c ${TAREXCL} -f - ${module} | ( cd $PAYLOAD/rerun/modules; tar xpf - )
         popd >/dev/null
       fi
@@ -196,7 +197,7 @@ build_deb_archive() {
 
   for MODULE in ${MODULES}
   do
-    MODULE_DIR=${RERUN_MODULES}/${MODULE}
+    MODULE_DIR=$(rerun_module_exists $MODULE)
     [[ -r ${MODULE_DIR}/metadata ]] || rerun_die "Can not find module ${MODULE}"
 
     # Setup a temporary directory to build the deb:
@@ -292,7 +293,7 @@ build_rpm_archive() {
 
   for MODULE in ${MODULES}
   do
-    MODULE_DIR=${RERUN_MODULES}/${MODULE}
+    MODULE_DIR=$(rerun_module_exists $MODULE)
     if [[ -r ${MODULE_DIR}/metadata ]]
     then
       # Setup a temporary directory to build the RPM:

--- a/modules/stubbs/commands/docs/script
+++ b/modules/stubbs/commands/docs/script
@@ -59,7 +59,8 @@ set -o nounset -o pipefail
 # -----------------
 
 # Change directory to be relative to what would be RERUN_MODULE_DIR.
-cd $RERUN_MODULES/$MODULE
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+cd $RERUN_MODULE_HOME_DIR
 
 # Check the specified directory and default it if necessary.
 # 
@@ -69,7 +70,7 @@ if [[ -n "${DIR:-}" ]]
 then
     DIR=$(rerun_path_absolute "$DIR")
 else
-    DIR="$RERUN_MODULES/$MODULE/docs"
+    DIR="$RERUN_MODULE_HOME_DIR/docs"
 fi
 
 # Create the documentation directory.
@@ -175,7 +176,7 @@ done
 cat >$DIR/index.md <<MARKDOWN
 # $MODULE
 
-$(rerun_property_get $RERUN_MODULES/$MODULE DESCRIPTION)
+$(rerun_property_get $RERUN_MODULE_HOME_DIR DESCRIPTION)
 
 ## SYNOPSIS
 
@@ -215,7 +216,7 @@ MARKDOWN
 
 # Path to the unix manual page. 
 MANPAGE=$DIR/$MODULE.1
-VERSION="$(rerun_property_get $RERUN_MODULES/$MODULE VERSION)" || { VERSION=1 ; }
+VERSION="$(rerun_property_get $RERUN_MODULE_HOME_DIR VERSION)" || { VERSION=1 ; }
 docs_man_page "$VERSION" "$MODULE" > $MANPAGE
 rerun_log info "Unix manual: $MANPAGE"
 

--- a/modules/stubbs/commands/edit/script
+++ b/modules/stubbs/commands/edit/script
@@ -92,13 +92,15 @@ done
     done
 }
 
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+
 # Verify this command exists
 #
-[ -d $RERUN_MODULES/$MODULE/commands/$COMMAND ] || {
+[ -d $RERUN_MODULE_HOME_DIR/commands/$COMMAND ] || {
     rerun_die "command not found: \""$MODULE:$COMMAND\"""
 }
 
-[ ! -f $RERUN_MODULES/$MODULE/commands/$COMMAND/script ] && {
+[ ! -f $RERUN_MODULE_HOME_DIR/commands/$COMMAND/script ] && {
     rerun_die "command script not found for $MODULE:$COMMAND. Create one with stubbs:add-command."
 }
 
@@ -106,7 +108,7 @@ done
 
 : ${EDITOR:=vi}
 
-exec $EDITOR $RERUN_MODULES/$MODULE/commands/$COMMAND/script
+exec $EDITOR $RERUN_MODULE_HOME_DIR/commands/$COMMAND/script
 
 # Done
 

--- a/modules/stubbs/commands/migrate/script
+++ b/modules/stubbs/commands/migrate/script
@@ -41,7 +41,7 @@ set -o nounset -o pipefail
 # ----------------------
 
 
-MODULE_DIR=$RERUN_MODULES/$MODULE
+MODULE_DIR=$(rerun_module_exists $MODULE)
 
 [[ ! -d "$MODULE_DIR" ]] && {
     die "module directory not found: $MODULE_DIR"

--- a/modules/stubbs/commands/rm-command/script
+++ b/modules/stubbs/commands/rm-command/script
@@ -89,17 +89,19 @@ done
     done
 }
 
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+
 #
 # Verify specified command exists.
 #
-[[ -d $RERUN_MODULES/$MODULE/commands/$COMMAND ]] || {
+[[ -d $RERUN_MODULE_HOME_DIR/commands/$COMMAND ]] || {
     exit 0
 }
 
 #
 # Remove tests for this command.
 #
-rm -f $RERUN_MODULES/$MODULE/tests/$COMMAND-*-test.sh
+rm -f $RERUN_MODULE_HOME_DIR/tests/$COMMAND-*-test.sh
 
 #
 # Look up the options used by this command and remove any would be unused option.
@@ -108,18 +110,18 @@ command_options=( $(rerun_options $RERUN_MODULES $MODULE $COMMAND) )
 for opt in ${command_options[*]:-}
 do  
     # Check if this option is only assigned to this command.
-    commands_assigned_to_option=( $(stubbs_option_commands $RERUN_MODULES/$MODULE $opt) )
+    commands_assigned_to_option=( $(stubbs_option_commands $RERUN_MODULE_HOME_DIR $opt) )
     if [[ ${#commands_assigned_to_option[*]} == 1 && $commands_assigned_to_option == $COMMAND ]]
     then
         #
         # Remove the option since only this command was assigned to it.
         #
-        if [[ -d  "$RERUN_MODULES/$MODULE/options/$opt" ]]
+        if [[ -d  "$RERUN_MODULE_HOME_DIR/options/$opt" ]]
         then
-            rm -rf "$RERUN_MODULES/$MODULE/options/$opt" || {
+            rm -rf "$RERUN_MODULE_HOME_DIR/options/$opt" || {
                 rerun_die "Error removing option: $opt"
             }
-            rerun_log info "Removed $RERUN_MODULES/$MODULE/options/$opt"
+            rerun_log info "Removed $RERUN_MODULE_HOME_DIR/options/$opt"
         fi
     fi
 done
@@ -127,7 +129,7 @@ done
 #
 # Remove the command directory from the module.
 #
-rm -rf $RERUN_MODULES/$MODULE/commands/$COMMAND
+rm -rf $RERUN_MODULE_HOME_DIR/commands/$COMMAND
 
 # Done
 exit $?

--- a/modules/stubbs/commands/rm-option/script
+++ b/modules/stubbs/commands/rm-option/script
@@ -99,13 +99,15 @@ done
     read OPTION
 }
 
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+
 COMMAND_LIST=( ${COMMAND//,/ } )
 for cmd in ${COMMAND_LIST[*]}
 do
     #
     # Verify this command exists
     #
-    [ -d $RERUN_MODULES/$MODULE/commands/$cmd ] || {
+    [ -d $RERUN_MODULE_HOME_DIR/commands/$cmd ] || {
         rerun_log warn "command not found: \""$MODULE:$cmd\""...skipping."
         continue
     }
@@ -113,29 +115,29 @@ do
     # Unassign this command from the option
     #
     # Update the command metadata.
-    command_metadata=$RERUN_MODULES/$MODULE/commands/$cmd/metadata
+    command_metadata=$RERUN_MODULE_HOME_DIR/commands/$cmd/metadata
     command_options_assignments=$(rerun_options $RERUN_MODULES $MODULE $cmd)
     # Subtract option from the list
     command_options=( $(rerun_list_remove $OPTION $command_options_assignments) )
 
     stubbs_command_options_write \
-        $RERUN_MODULES/$MODULE $cmd \
+        $RERUN_MODULE_HOME_DIR $cmd \
         "${command_options[*]:-}" || rerun_die "Failed generating command metadata"
     rerun_log info "Updated command metadata:  $command_metadata"
     #
     # Check if this option is assigned to any commands.
-    option_to_command_assignments=( $(stubbs_option_commands $RERUN_MODULES/$MODULE $OPTION) )
+    option_to_command_assignments=( $(stubbs_option_commands $RERUN_MODULE_HOME_DIR $OPTION) )
     #
     # Remove the option directory, if no commands are assigned to it.
     #
     if [ ${#option_to_command_assignments[*]} = 0 ]
     then
-        if [[ -d  "$RERUN_MODULES/$MODULE/options/$OPTION" ]]
+        if [[ -d  "$RERUN_MODULE_HOME_DIR/options/$OPTION" ]]
         then
-            rm -rf "$RERUN_MODULES/$MODULE/options/$OPTION" || {
+            rm -rf "$RERUN_MODULE_HOME_DIR/options/$OPTION" || {
                 rerun_die "Error removing option: $OPTION"
             }
-            rerun_log info "Removed $RERUN_MODULES/$MODULE/options/$OPTION"
+            rerun_log info "Removed $RERUN_MODULE_HOME_DIR/options/$OPTION"
         fi
     fi
     #
@@ -150,19 +152,19 @@ do
     [ -z "$OPTIONS_SCRIPT" ] && {
         rerun_die "required metadata not found: OPTIONS_SCRIPT"
     }
-    options_parser=$RERUN_MODULES/$MODULE/commands/$cmd/$OPTIONS_SCRIPT
+    options_parser=$RERUN_MODULE_HOME_DIR/commands/$cmd/$OPTIONS_SCRIPT
     # Generate it
     $RERUN_MODULE_DIR/lib/stub/bash/$OPTIONS_GENERATOR \
         $RERUN_MODULES $MODULE $cmd > $options_parser || rerun_die "Failed generating options parser."
-    rerun_log info "Wrote options script: $RERUN_MODULES/$MODULE/commands/$cmd/options.sh"
+    rerun_log info "Wrote options script: $RERUN_MODULE_HOME_DIR/commands/$cmd/options.sh"
     #
     # Update option variable summary in command script.
     #
-    command_script=$RERUN_MODULES/$MODULE/commands/$cmd/script
+    command_script=$RERUN_MODULE_HOME_DIR/commands/$cmd/script
     if [ -f "$command_script" ]
     then
         stubbs_script_header \
-            $RERUN_MODULES/$MODULE $cmd > ${command_script}.$$ || {
+            $RERUN_MODULE_HOME_DIR $cmd > ${command_script}.$$ || {
             rerun_die "Error updating command script header"
         }
         mv $command_script.$$ $command_script || {

--- a/modules/stubbs/commands/test/script
+++ b/modules/stubbs/commands/test/script
@@ -75,7 +75,8 @@ done
 [ -z "${MODULE:-}" ] &&  { rerun_syntax_error "missing required option: --module"; }
 [ -z "${PLAN:-}" ] && PLAN="*"
 
-if [ ! -d "$RERUN_MODULES/$MODULE/tests" ]
+RERUN_MODULE_HOME_DIR=$(rerun_module_exists $MODULE)
+if [ ! -d "$RERUN_MODULE_HOME_DIR/tests" ]
 then
     # there should always be at least one test!
     rerun_die "No tests" 
@@ -96,7 +97,7 @@ echo $(rerun_color blue "=======================================================
     export ANSWERS=${ANSWERS:-}
 
     # Roundup likes to run relative
-    cd $RERUN_MODULES/$MODULE/tests
+    cd $RERUN_MODULE_HOME_DIR/tests
 
     # Run the tests
     #

--- a/modules/stubbs/tests/add-command-1-test.sh
+++ b/modules/stubbs/tests/add-command-1-test.sh
@@ -12,28 +12,31 @@ rerun() {
 }
 
 before() {
-    mkdir -p $RERUN_MODULES/freddy
-    cat > $RERUN_MODULES/freddy/metadata <<EOF
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+    mkdir -p $first_rerun_module_dir/freddy
+    cat > $first_rerun_module_dir/freddy/metadata <<EOF
 NAME=freddy
 DESCRIPTION=
 EOF
 }
 
 after() {
-    rm -r $RERUN_MODULES/freddy
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+    rm -r $first_rerun_module_dir/freddy
 }
 
 validate() {
-    test -d $RERUN_MODULES/freddy/commands/dance
-    test -f $RERUN_MODULES/freddy/commands/dance/metadata
-    .  $RERUN_MODULES/freddy/commands/dance/metadata
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+    test -d $first_rerun_module_dir/freddy/commands/dance
+    test -f $first_rerun_module_dir/freddy/commands/dance/metadata
+    .  $first_rerun_module_dir/freddy/commands/dance/metadata
     test -n "$NAME" -a $NAME = dance 
     test -n "$DESCRIPTION" -a "$DESCRIPTION" = "tell freddy to dance"
-    test -f $RERUN_MODULES/freddy/commands/dance/script
-    test -f $RERUN_MODULES/freddy/tests/functions.sh
-    test -f $RERUN_MODULES/freddy/tests/dance-1-test.sh
+    test -f $first_rerun_module_dir/freddy/commands/dance/script
+    test -f $first_rerun_module_dir/freddy/tests/functions.sh
+    test -f $first_rerun_module_dir/freddy/tests/dance-1-test.sh
     grep '[[ -f ./functions.sh ]] && . ./functions.sh' \
-        $RERUN_MODULES/freddy/tests/dance-1-test.sh
+        $first_rerun_module_dir/freddy/tests/dance-1-test.sh
 }
 
 

--- a/modules/stubbs/tests/add-module-1-test.sh
+++ b/modules/stubbs/tests/add-module-1-test.sh
@@ -12,14 +12,15 @@ rerun() {
 }
 
 validate() {
-    test -f $RERUN_MODULES/freddy/metadata
-    .  $RERUN_MODULES/freddy/metadata
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+    test -f $first_rerun_module_dir/freddy/metadata
+    .  $first_rerun_module_dir/freddy/metadata
     test -n "$NAME" -a "$NAME" = freddy 
     test -n "$DESCRIPTION" -a "$DESCRIPTION" = "A dancer in a red beret and matching suspenders"
     test -n "$SHELL" -a "$SHELL" = "bash"
     test "$VERSION" = "1.0.0"
-    grep '^REQUIRES=' $RERUN_MODULES/freddy/metadata
-    grep '^EXTERNALS=' $RERUN_MODULES/freddy/metadata
+    grep '^REQUIRES=' $first_rerun_module_dir/freddy/metadata
+    grep '^EXTERNALS=' $first_rerun_module_dir/freddy/metadata
 
 }
 
@@ -53,19 +54,21 @@ it_should_add_module_from_template() {
         --description "A dancer in a red beret and matching suspenders" \
 
    # Create freddy:dance
-   mkdir -p $RERUN_MODULES/freddy/commands/dance
-   cat > $RERUN_MODULES/freddy/commands/dance/metadata <<EOF
+   first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+   mkdir -p $first_rerun_module_dir/freddy/commands/dance
+   cat > $first_rerun_module_dir/freddy/commands/dance/metadata <<EOF
 NAME=dance
 OPTIONS=
 EOF
-   cat > $RERUN_MODULES/freddy/commands/dance/script <<EOF
+   cat > $first_rerun_module_dir/freddy/commands/dance/script <<EOF
 #!/bin/bash
 #/ command: freddy:dance "watch freddy dance"
 #/ usage: rerun freddy:dance 
 trap 'rerun_die $? "*** command failed: freddy:dance. ***"' ERR
 EOF
-   mkdir -p $RERUN_MODULES/freddy/tests
-   cat > $RERUN_MODULES/freddy/tests/dance-1-test.sh <<EOF
+   mkdir -p $first_rerun_module_dir/freddy/tests
+   cat > $first_rerun_module_dir/freddy/tests/dance-1-test.sh <<EOF
 #!/usr/bin/env roundup
 #/ usage: rerun stubbs:test -m freddy -p dance 
 describe "dance"
@@ -78,26 +81,28 @@ EOF
        --template freddy
 
    # Check the metadata properties retain roger values.
-   test -f $RERUN_MODULES/roger/metadata
-   .  $RERUN_MODULES/roger/metadata
+   test -f $first_rerun_module_dir/roger/metadata
+   .  $first_rerun_module_dir/roger/metadata
    test -n "$NAME" -a "$NAME" = roger 
    test -n "$DESCRIPTION" -a "$DESCRIPTION" = "Another friend of rerun"
    test "${VERSION}" = "1.0.0"
 
     # No lingering freddy text should remain.
-   ! grep freddy $RERUN_MODULES/roger/commands/*/script
-   ! grep freddy $RERUN_MODULES/roger/tests/*.sh
+   ! grep freddy $first_rerun_module_dir/roger/commands/*/script
+   ! grep freddy $first_rerun_module_dir/roger/tests/*.sh
 
     # The new module name should be preserved.
-   grep roger $RERUN_MODULES/roger/commands/*/script
-   grep roger $RERUN_MODULES/roger/tests/*.sh
+   grep roger $first_rerun_module_dir/roger/commands/*/script
+   grep roger $first_rerun_module_dir/roger/tests/*.sh
 
-   rm -r  $RERUN_MODULES/roger
+   rm -r  $first_rerun_module_dir/roger
 }
 
 it_takes_descriptions_w_commas_slashes() {
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
     rerun stubbs:add-module --module "freddy" \
         --description "A dancer, in a red/burgundy beret"
-   .  $RERUN_MODULES/freddy/metadata
+   .  $first_rerun_module_dir/freddy/metadata
    test "$DESCRIPTION" = "A dancer, in a red/burgundy beret"
 }

--- a/modules/stubbs/tests/archive-1-test.sh
+++ b/modules/stubbs/tests/archive-1-test.sh
@@ -57,9 +57,11 @@ it_handles_comands_using_quoted_arguments() {
     rerun stubbs:add-command --module freddy --command says --description "none"
     rerun stubbs:add-option --module freddy --command says --option msg \
         --description none --required true --export false --default nothing
-    cat ${RERUN_MODULES}/freddy/commands/says/script |
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cat ${first_rerun_module_dir}/freddy/commands/says/script |
         sed 's/# Put the command implementation here./echo "msg ($MSG)"/g' > /tmp/script.$$
-    mv /tmp/script.$$ ${RERUN_MODULES}/freddy/commands/says/script
+    mv /tmp/script.$$ ${first_rerun_module_dir}/freddy/commands/says/script
 
     rerun stubbs:archive --file /tmp/rerun.sh.$$ --modules freddy --version 1.0
 
@@ -67,7 +69,7 @@ it_handles_comands_using_quoted_arguments() {
     test "$output" = "msg (whats happening)"
     
     rm /tmp/rerun.sh.$$
-    rm -r ${RERUN_MODULES}/freddy
+    rm -r ${first_rerun_module_dir}/freddy
 }
 
 it_builds_the_stubbs_module_rpm() {
@@ -87,7 +89,9 @@ it_builds_the_stubbs_module_rpm() {
     TMPDIR=$(mktemp -d "/tmp/rerun.test.XXXX")
     pushd $TMPDIR
     rerun stubbs:archive --format rpm --modules stubbs --release 1
-    RPM1=rerun-stubbs-$(grep ^VERSION=  ${RERUN_MODULES}/stubbs/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    RPM1=rerun-stubbs-$(grep ^VERSION=  ${first_rerun_module_dir}/stubbs/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
     rpm -qi -p ${RPM1} | grep stubbs
     popd
     rm -rf ${TMPDIR}
@@ -113,20 +117,22 @@ it_builds_a_list_of_rpms() {
     rerun stubbs:add-command --module dance --command says --description "none"
     rerun stubbs:add-option --module dance --command says --option msg \
         --description none --required true --export false --default nothing
-    mkdir ${RERUN_MODULES}/freddy/commands/.git ${RERUN_MODULES}/freddy/commands/.svn
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    mkdir ${first_rerun_module_dir}/freddy/commands/.git ${first_rerun_module_dir}/freddy/commands/.svn
     TMPDIR=$(mktemp -d "/tmp/rerun.test.XXXX")
     pushd $TMPDIR
 
     rerun stubbs:archive --format rpm --modules "freddy dance" --release 1 --version "1.2.3"
 
-    RPM1=rerun-freddy-$(grep ^VERSION=  ${RERUN_MODULES}/freddy/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
-    RPM2=rerun-dance-$(grep ^VERSION=  ${RERUN_MODULES}/dance/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
+    RPM1=rerun-freddy-$(grep ^VERSION=  ${first_rerun_module_dir}/freddy/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
+    RPM2=rerun-dance-$(grep ^VERSION=  ${first_rerun_module_dir}/dance/metadata | cut -d= -f2)-1${MYDIST}.noarch.rpm
     rpm -qi -p ${RPM1} | grep freddy
     rpm -qi -p ${RPM2} | grep dance
     rpm2cpio ${RPM1} | cpio -t - | grep "\/\.git$" && exit 1
     rpm2cpio ${RPM1} | cpio -t - | grep "\/\.svn$" && exit 1
     popd
-    rm -rf ${TMPDIR} ${RERUN_MODULES}/freddy ${RERUN_MODULES}/dance
+    rm -rf ${TMPDIR} ${first_rerun_module_dir}/freddy ${first_rerun_module_dir}/dance
 }
 
 it_builds_a_list_of_debs() {
@@ -140,7 +146,9 @@ it_builds_a_list_of_debs() {
     rerun stubbs:add-command --module dance --command says --description "none"
     rerun stubbs:add-option --module dance --command says --option msg \
         --description none --required true --export false --default nothing
-    mkdir ${RERUN_MODULES}/freddy/commands/.git ${RERUN_MODULES}/freddy/commands/.svn
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    mkdir ${first_rerun_module_dir}/freddy/commands/.git ${first_rerun_module_dir}/freddy/commands/.svn
     TMPDIR=$(mktemp -d "/tmp/rerun.test.XXXX")
     pushd $TMPDIR
 
@@ -153,7 +161,7 @@ it_builds_a_list_of_debs() {
     dpkg-deb --contents ${DEB1} | grep "\/\.git$" && exit 1
     dpkg-deb --contents ${DEB1} | grep "\/\.svn$" && exit 1
     popd
-    rm -rf ${TMPDIR} ${RERUN_MODULES}/freddy ${RERUN_MODULES}/dance
+    rm -rf ${TMPDIR} ${first_rerun_module_dir}/freddy ${first_rerun_module_dir}/dance
 }
 
 it_extracts_only_and_exits() {
@@ -161,8 +169,10 @@ it_extracts_only_and_exits() {
     rerun stubbs:add-command --module freddy --command says --description "none"
     rerun stubbs:add-option --module freddy --command says --option msg \
         --description none --required true --export false --default nothing
-    mkdir ${RERUN_MODULES}/freddy/.svn
-    mkdir ${RERUN_MODULES}/freddy/.git
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    mkdir ${first_rerun_module_dir}/freddy/.svn
+    mkdir ${first_rerun_module_dir}/freddy/.git
     rerun stubbs:archive --file /tmp/rerun.sh.$$ --modules freddy --version 1.0
 
     /tmp/rerun.sh.$$ --extract-only /tmp/myextract.$$
@@ -175,7 +185,7 @@ it_extracts_only_and_exits() {
     [[ -e /tmp/myextract.$$/rerun/modules/freddy/.svn ]] && exit 1
     [[ -e /tmp/myextract.$$/rerun/modules/freddy/.git ]] && exit 1
 
-    rm -rf /tmp/myextract.$$ /tmp/rerun.sh.$$ ${RERUN_MODULES}/freddy
+    rm -rf /tmp/myextract.$$ /tmp/rerun.sh.$$ ${first_rerun_module_dir}/freddy
 }
 
 
@@ -184,9 +194,11 @@ it_runs_from_specified_extract_dir() {
     rerun stubbs:add-command --module freddy --command says --description "none"
     rerun stubbs:add-option --module freddy --command says --option msg \
         --description none --required true --export false --default nothing
-    cat ${RERUN_MODULES}/freddy/commands/says/script |
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cat ${first_rerun_module_dir}/freddy/commands/says/script |
     sed 's/# Put the command implementation here./echo "msg ($MSG)"/g' > /tmp/script.$$
-    mv /tmp/script.$$ ${RERUN_MODULES}/freddy/commands/says/script
+    mv /tmp/script.$$ ${first_rerun_module_dir}/freddy/commands/says/script
 
     rerun stubbs:archive --file /tmp/rerun.sh.$$ --modules freddy --version 1.0
 
@@ -195,7 +207,7 @@ it_runs_from_specified_extract_dir() {
     OUT=$(/tmp/rerun.sh.$$ --extract-dir /tmp/myextract.$$ freddy:says --msg hi)
     test "$OUT" = "msg (hi)"
     rm /tmp/rerun.sh.$$
-    rm -rf ${RERUN_MODULES}/freddy /tmp/myextract.$$
+    rm -rf ${first_rerun_module_dir}/freddy /tmp/myextract.$$
 }
 
 it_runs_archive_from_overridden_TMPDIR() {
@@ -205,9 +217,11 @@ it_runs_archive_from_overridden_TMPDIR() {
     rerun stubbs:add-module --module freddy --description "none"
     rerun stubbs:add-command --module freddy --command print_tmpdir --description "none"
 
-    cat ${RERUN_MODULES}/freddy/commands/print_tmpdir/script |
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cat ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script |
     sed 's,# Put the command implementation here.,echo "$TMPDIR",g' > /tmp/script.$$
-    mv /tmp/script.$$ ${RERUN_MODULES}/freddy/commands/print_tmpdir/script
+    mv /tmp/script.$$ ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script
 
     rerun stubbs:archive --file /tmp/rerun.sh.$$ --modules freddy --version 1.0
 
@@ -220,31 +234,37 @@ it_runs_archive_from_overridden_TMPDIR() {
 it_errors_with_missing_extract_dir_arg(){
     rerun stubbs:add-module --module freddy --description "none"
     rerun stubbs:add-command --module freddy --command print_tmpdir --description "none"
-    cat ${RERUN_MODULES}/freddy/commands/print_tmpdir/script |
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cat ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script |
     sed 's,# Put the command implementation here.,echo "$TMPDIR",g' > /tmp/script.$$
-    mv /tmp/script.$$ ${RERUN_MODULES}/freddy/commands/print_tmpdir/script
+    mv /tmp/script.$$ ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script
 
     rerun stubbs:archive --file /tmp/rerun.sh.$$ --modules freddy --version 1.0
     ERR=$(mktemp /tmp/rerun.archive.err.$$.XXXX)
     ! /tmp/rerun.sh.$$ --extract-only 2> $ERR
     usage="usage: rerun.sh.$$ [--archive-version-release] [--extract-only|-N <>] [--extract-dir|-D <>] [module]:[command] [options]"
     test "${usage}" = "$(cat $ERR)"
-    rm -rf /tmp/rerun.sh.$$ /tmp/stubbs.archive.$$ $ERR ${RERUN_MODULES}/freddy
+    rm -rf /tmp/rerun.sh.$$ /tmp/stubbs.archive.$$ $ERR ${first_rerun_module_dir}/freddy
 }
 
 it_creates_archive_with_user_template() {
     # Create a copy of the original template scripts
     my_template=$(mktemp -d "/tmp/it_creates_archive_with_user_template.XXX")
-    cp -rv ${RERUN_MODULES}/stubbs/templates/{extract,launcher} $my_template
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cp -rv ${first_rerun_module_dir}/stubbs/templates/{extract,launcher} $my_template
     # Change the usage comment so we know it's our custom one.
     sed -i -e "s^#/ usage:.*^#/ usage: custom stuff^" $my_template/extract
 
     # Create a module to archive
     rerun stubbs:add-module --module freddy --description "none"
     rerun stubbs:add-command --module freddy --command print_tmpdir --description "none"
-    cat ${RERUN_MODULES}/freddy/commands/print_tmpdir/script |
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    cat ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script |
       sed 's,# Put the command implementation here.,echo "$TMPDIR",g' > /tmp/script.$$
-    mv /tmp/script.$$ ${RERUN_MODULES}/freddy/commands/print_tmpdir/script
+    mv /tmp/script.$$ ${first_rerun_module_dir}/freddy/commands/print_tmpdir/script
 
     # Archive it.
     rerun stubbs:archive --template $my_template --file /tmp/rerun.sh.$$ --modules freddy --version 1.0

--- a/modules/stubbs/tests/functional-bash-1-test.sh
+++ b/modules/stubbs/tests/functional-bash-1-test.sh
@@ -12,7 +12,9 @@ rerun() {
 }
 
 after() {
-   rm -rf $RERUN_MODULES/freddy
+   first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+   rm -rf $first_rerun_module_dir/freddy
 }
 
 # The Plan
@@ -29,7 +31,9 @@ it_builds_a_functional_module() {
     rerun stubbs:add-command --module "freddy" \
         --command dance --description "tell freddy to dance"
 
-    command_script=$RERUN_MODULES/freddy/commands/dance/script
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    command_script=$first_rerun_module_dir/freddy/commands/dance/script
     # Be sure the command script has execute bit set 
     test -x $command_script
     

--- a/modules/stubbs/tests/rm-command-1-test.sh
+++ b/modules/stubbs/tests/rm-command-1-test.sh
@@ -17,47 +17,51 @@ rerun() {
 # Mock a freddy module with two commands and two options.
 #
 before() {
-    mkdir -p $RERUN_MODULES/freddy
-    cat > $RERUN_MODULES/freddy/metadata <<EOF
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    mkdir -p $first_rerun_module_dir/freddy
+    cat > $first_rerun_module_dir/freddy/metadata <<EOF
 NAME=freddy
 DESCRIPTION="mock freddy module."
 EOF
 
-    mkdir -p $RERUN_MODULES/freddy/options/jumps
-    cat > $RERUN_MODULES/freddy/options/jumps/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/options/jumps
+    cat > $first_rerun_module_dir/freddy/options/jumps/metadata <<EOF
 NAME=jumps
 DESCRIPTION="number jumps"
 EOF
-    mkdir -p $RERUN_MODULES/freddy/options/slides
-    cat > $RERUN_MODULES/freddy/options/slides/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/options/slides
+    cat > $first_rerun_module_dir/freddy/options/slides/metadata <<EOF
 NAME=slides
 DESCRIPTION="number slides"
 EOF
 
-    mkdir -p $RERUN_MODULES/freddy/commands/dance
-    cat > $RERUN_MODULES/freddy/commands/dance/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/commands/dance
+    cat > $first_rerun_module_dir/freddy/commands/dance/metadata <<EOF
 NAME=dance
 DESCRIPTION="mock dance command"
 OPTIONS="jumps"
 EOF
 
-    mkdir -p $RERUN_MODULES/freddy/commands/groove
-    cat > $RERUN_MODULES/freddy/commands/groove/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/commands/groove
+    cat > $first_rerun_module_dir/freddy/commands/groove/metadata <<EOF
 NAME=groove
 DESCRIPTION="mock groove command"
 OPTIONS="slides"
 EOF
 
-    mkdir -p $RERUN_MODULES/freddy/tests
-    touch $RERUN_MODULES/freddy/tests/dance-1-test.sh 
-    touch $RERUN_MODULES/freddy/tests/groove-1-test.sh 
+    mkdir -p $first_rerun_module_dir/freddy/tests
+    touch $first_rerun_module_dir/freddy/tests/dance-1-test.sh 
+    touch $first_rerun_module_dir/freddy/tests/groove-1-test.sh 
 
     return $?
 }
 
 # Remove the mock module directory.
 after() {
-    rm -r $RERUN_MODULES/freddy
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    rm -r $first_rerun_module_dir/freddy
 }
 
 
@@ -75,37 +79,43 @@ it_prompts_user_for_command() {
 1
 EOF
 
-    ! test -d $RERUN_MODULES/freddy/commands/dance
-    ! test -d $RERUN_MODULES/freddy/options/jumps
-    ! test -f $RERUN_MODULES/freddy/tests/dance-1-test.sh
-    test -d $RERUN_MODULES/freddy/commands/groove
-    test -f $RERUN_MODULES/freddy/tests/groove-1-test.sh    
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    ! test -d $first_rerun_module_dir/freddy/commands/dance
+    ! test -d $first_rerun_module_dir/freddy/options/jumps
+    ! test -f $first_rerun_module_dir/freddy/tests/dance-1-test.sh
+    test -d $first_rerun_module_dir/freddy/commands/groove
+    test -f $first_rerun_module_dir/freddy/tests/groove-1-test.sh    
 }
 
 # Run the command with all options.
 # Be sure test and option is removed.
 it_removes_specified_command() {
     rerun stubbs:rm-command --module freddy --command dance 
-    ! test -d $RERUN_MODULES/freddy/commands/dance
-    ! test -d $RERUN_MODULES/freddy/options/jumps    
-    ! test -f $RERUN_MODULES/freddy/tests/dance-1-test.sh    
-    test -d $RERUN_MODULES/freddy/commands/groove    
-    test -f $RERUN_MODULES/freddy/tests/groove-1-test.sh    
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+    ! test -d $first_rerun_module_dir/freddy/commands/dance
+    ! test -d $first_rerun_module_dir/freddy/options/jumps    
+    ! test -f $first_rerun_module_dir/freddy/tests/dance-1-test.sh    
+    test -d $first_rerun_module_dir/freddy/commands/groove    
+    test -f $first_rerun_module_dir/freddy/tests/groove-1-test.sh    
 }
 
 # Create a third command that shares the "--jumps" option.
 # Be sure the jumps option remains after the "dance" command is removed.
 it_leaves_shared_option_if_other_command_assigned() {
-  mkdir -p $RERUN_MODULES/freddy/commands/shuffle
-    cat > $RERUN_MODULES/freddy/commands/shuffle/metadata <<EOF
+    first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+  mkdir -p $first_rerun_module_dir/freddy/commands/shuffle
+    cat > $first_rerun_module_dir/freddy/commands/shuffle/metadata <<EOF
 NAME=shuffle
 DESCRIPTION="mock shuffle command"
 OPTIONS="slides jumps"
 EOF
 
     rerun stubbs:rm-command --module freddy --command dance 
-    ! test -d $RERUN_MODULES/freddy/commands/dance    
-    test -d $RERUN_MODULES/freddy/options/jumps    
+    ! test -d $first_rerun_module_dir/freddy/commands/dance    
+    test -d $first_rerun_module_dir/freddy/options/jumps    
 }
 
 

--- a/modules/stubbs/tests/stubbs-functions-1-test.sh
+++ b/modules/stubbs/tests/stubbs-functions-1-test.sh
@@ -6,7 +6,9 @@
 
 # Helpers
 # ------------
-. $RERUN_MODULES/stubbs/lib/functions.sh || exit 1
+first_rerun_module_dir=$(echo "$RERUN_MODULES" | cut -d: -f1)
+
+. $first_rerun_module_dir/stubbs/lib/functions.sh || exit 1
 
 rerun() {
     command $RERUN -M $RERUN_MODULES "$@"
@@ -14,28 +16,28 @@ rerun() {
 
 before() {
     # Mock a module and command
-    mkdir -p $RERUN_MODULES/freddy
-    cat > $RERUN_MODULES/freddy/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy
+    cat > $first_rerun_module_dir/freddy/metadata <<EOF
 NAME=freddy
 EOF
-    mkdir -p $RERUN_MODULES/freddy/commands/dance
-    cat > $RERUN_MODULES/freddy/commands/dance/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/commands/dance
+    cat > $first_rerun_module_dir/freddy/commands/dance/metadata <<EOF
 NAME=dance
 OPTIONS=
 EOF
 
-    cat > $RERUN_MODULES/freddy/commands/dance/script <<EOF
+    cat > $first_rerun_module_dir/freddy/commands/dance/script <<EOF
 #!/bin/bash
 #/ command: freddy:dance "watch freddy dance"
 #/ usage: rerun freddy:dance 
 trap 'rerun_die $? "*** command failed: freddy:dance. ***"' ERR
 EOF
-    mkdir -p $RERUN_MODULES/freddy/commands/study
-    cat > $RERUN_MODULES/freddy/commands/study/metadata <<EOF
+    mkdir -p $first_rerun_module_dir/freddy/commands/study
+    cat > $first_rerun_module_dir/freddy/commands/study/metadata <<EOF
 NAME=study
 OPTIONS=
 EOF
-    cat > $RERUN_MODULES/freddy/commands/study/script <<EOF
+    cat > $first_rerun_module_dir/freddy/commands/study/script <<EOF
 #!/bin/bash
 #/ command: freddy:study "watch freddy study"
 #/ usage: rerun freddy:study 
@@ -45,7 +47,7 @@ EOF
 
 after() {
     # clean up the mock module
-    rm -r $RERUN_MODULES/freddy
+    rm -r $first_rerun_module_dir/freddy
 }
 
 
@@ -70,7 +72,7 @@ it_performs_stubbs_option_commands() {
         --required true --export true --default true
 
     # Check the option-to-command assignments
-    local -a commands=( $(stubbs_option_commands $RERUN_MODULES/freddy jumps) )
+    local -a commands=( $(stubbs_option_commands $first_rerun_module_dir/freddy jumps) )
     
     rerun_list_contains dance "${commands[@]}" 
     ! rerun_list_contains study "${commands[@]}" 
@@ -80,7 +82,7 @@ it_performs_stubbs_option_commands() {
         --option jumps --description "jump #num times" \
         --required true --export true --default 3
     # Check the option-to-command assignments
-    local -a commands=( $(stubbs_option_commands $RERUN_MODULES/freddy jumps) )
+    local -a commands=( $(stubbs_option_commands $first_rerun_module_dir/freddy jumps) )
 
     test ${#commands[*]} = 2
     rerun_list_contains dance "${commands[@]}" 
@@ -90,7 +92,7 @@ it_performs_stubbs_option_commands() {
     rerun stubbs:rm-option --module freddy --command dance \
         --option jumps 
 
-    local -a commands=( $(stubbs_option_commands $RERUN_MODULES/freddy jumps) )
+    local -a commands=( $(stubbs_option_commands $first_rerun_module_dir/freddy jumps) )
 
     test ${#commands[*]} = 1
     ! rerun_list_contains dance "${commands[@]}" 
@@ -125,7 +127,7 @@ it_should_clone_a_module() {
 NAME=cloney
 DESCRIPTION="i am a clone"
 EOF
-    templatedir=$RERUN_MODULES/freddy
+    templatedir=$first_rerun_module_dir/freddy
     stubbs_module_clone $moduledir $templatedir
 
     test "$(rerun_property_get $moduledir NAME)" = "cloney"

--- a/rerun
+++ b/rerun
@@ -470,11 +470,11 @@ rerun_options_parse() {
 
 # _rerun_modules_ - List the modules by name.
 #
-#     rerun_modules directory 
+#     rerun_modules path 
 #
 # Arguments:
 #
-# * directory:     Directory containing modules.
+# * path:     Path to directories containing modules.
 #
 # Notes: 
 #
@@ -482,20 +482,52 @@ rerun_options_parse() {
 # 
 rerun_modules() {
     (( ! $# == 1 )) && { 
-	    rerun_die 'wrong # args: should be: rerun_modules directory'
+	    rerun_die 'wrong # args: should be: rerun_modules path'
     }
-    [[ ! -d $1 ]] && rerun_die "directory not found: $1"
     local -a modules
-    for f in $1/*/metadata
+    for dir in $(rerun_module_path_elements $1)
     do
-       if [[ -f $f ]]
-        then 
-            local module="$(basename $(dirname $f))" 
-            [[ -z "${modules:-}" ]] && modules=( $module ) || modules=( ${modules[*]} $module )
-        fi 
+        [[ ! -d $dir ]] && rerun_die "directory not found: $dir"
+        for f in $dir/*/metadata
+        do
+            if [[ -f $f ]]
+            then 
+                local module="$(basename $(dirname $f))" 
+                [[ -z "${modules:-}" ]] && modules=( $module ) || modules=( ${modules[*]} $module )
+            fi 
+        done
     done
-    echo ${modules[*]}
+    echo ${modules[*]} | sort | uniq
 }
+
+#
+# - - -
+#
+
+# _rerun_get_module_home_dir_in_path_ - Get the directory for the module in the path
+#
+#     rerun_get_module_home_dir_in_path path module
+#
+# Arguments:
+#
+# * path:     Path to directories containing modules.
+# * module:        Module name.
+#
+rerun_get_module_home_dir_in_path() {
+    (( $# == 2 )) || { 
+	    rerun_die 'wrong # args: should be: rerun_get_module_home_dir_in_path path module'
+    }
+    for dir in $(rerun_module_path_elements $1)
+    do
+        if [[ -f $dir/$2/metadata ]]
+        then
+            echo $dir/$2
+            return 0
+        fi
+    done
+    return 2
+}
+
 
 #
 # - - -
@@ -507,26 +539,27 @@ rerun_modules() {
 #
 # Arguments:
 #
-# * directory:     Directory containing modules.
+# * path:     Path to directories containing modules.
 # * module:        Module name.
 # Notes: 
 #
 # * Returns a list of space separated command names.
 # 
 rerun_commands() {
-   (( $# == 2 )) || { 
-	    rerun_die 'wrong # args: should be: rerun_commands directory module'
+    (( $# == 2 )) || { 
+	    rerun_die 'wrong # args: should be: rerun_commands path module'
     }
-    [[ ! -d $1 ]] && rerun_die "directory not found: $1"
+    local module_home="$(rerun_get_module_home_dir_in_path $1 $2)"
+    [[ -n $module_home ]] || rerun_die "module not found in path: $2 $1"
     local -a commands=()
-    for c in $1/$2/commands/*/metadata
-    do
-        if [[ -f $c ]]
-        then 
-            local command="$(basename $(dirname $c))" 
-            [[ -z "${commands:-}" ]] && commands=( $command ) || commands=( ${commands[*]} $command )
-        fi 
-    done
+	for c in $module_home/commands/*/metadata
+	do
+		if [[ -f $c ]]
+		then 
+			local command="$(basename $(dirname $c))" 
+			[[ -z "${commands:-}" ]] && commands=( $command ) || commands=( ${commands[*]} $command )
+		fi 
+	done
     echo ${commands[*]:-}
 }
 
@@ -541,7 +574,7 @@ rerun_commands() {
 #
 # Arguments:
 #
-# * directory:     Directory containing modules.
+# * path:     Path to directories containing modules.
 # * module:        Module name.
 # * command:       Command name.
 #
@@ -552,17 +585,16 @@ rerun_commands() {
 # 
 rerun_options() {
     (( $# == 3 )) || { 
-	    rerun_die 'wrong # args: should be: rerun_options modules_dir module command'
+	    rerun_die 'wrong # args: should be: rerun_options path module command'
     }
-    [[ ! -d $1 ]] && rerun_die "directory not found: $1"
-
-    local -r modules_dir="$1" module=$2 command=$3
-    if [[ -f $modules_dir/$module/commands/$command/metadata ]] 
-    then
-        ( .  $modules_dir/$module/commands/$command/metadata ; echo ${OPTIONS:-} )
-    else
-        echo ""
-    fi
+    local module_home="$(rerun_get_module_home_dir_in_path $1 $2)"
+    [[ -n $module_home ]] || rerun_die "module not found in path: $2 $1"
+	if [[ -f $module_home/commands/$3/metadata ]] 
+	then
+		( .  $module_home/commands/$3/metadata ; echo ${OPTIONS:-} )
+	else
+		echo ""
+	fi
 }
 
 #
@@ -575,7 +607,7 @@ rerun_options() {
 #
 # Arguments:
 #
-# * directory:     Directory containing modules.
+# * path:     Path to directories containing modules.
 # * module:        Module name.
 # Notes: 
 #
@@ -583,18 +615,19 @@ rerun_options() {
 # 
 rerun_module_options() {
     (( $# == 2 )) || { 
-	    rerun_die 'wrong # args: should be: rerun_module_options directory module'
+	    rerun_die 'wrong # args: should be: rerun_module_options path module'
     }
-    [[ ! -d $1 ]] && rerun_die "directory not found: $1"
+    local module_home="$(rerun_get_module_home_dir_in_path $1 $2)"
+    [[ -n $module_home ]] || rerun_die "module not found in path: $2 $1"
     local -a options=()
-    for o in $1/$2/options/*/metadata
-    do
-        if [[ -f $o ]]
-        then 
-            local option="$(basename $(dirname $o))" 
-            [[ -z "${options:-}" ]] && options=( $option ) || options=( ${options[*]} $option )
-        fi 
-    done
+	for o in $module_home/options/*/metadata
+	do
+		if [[ -f $o ]]
+		then 
+			local option="$(basename $(dirname $o))" 
+			[[ -z "${options:-}" ]] && options=( $option ) || options=( ${options[*]} $option )
+		fi 
+	done
     echo ${options[*]:-}
 }
 
@@ -725,7 +758,7 @@ rerun_path_absolute() {
 
 # _rerun_property_get_ - Print the value for the specified metadata property.
 #
-#     rerun_property_get directory  property
+#     rerun_property_get path  property
 #
 # Arguments:
 #
@@ -742,7 +775,7 @@ rerun_path_absolute() {
 
 rerun_property_get() {
     (( $# >= 2 )) || {
-        rerun_die 'wrong # args: should be: rerun_property_get directory property ?expand?'
+        rerun_die 'wrong # args: should be: rerun_property_get path property ?expand?'
     }
     local -r directory="$1" property="$2" expand="${3:-true}"
     [[ ! -f ${directory}/metadata ]] && rerun_die "metadata not found: ${directory}/metadata"
@@ -755,9 +788,8 @@ rerun_property_get() {
     then (set +u; . ${directory}/metadata; eval echo \$${property:-}; set -u)
     else echo "${prop#*=}"
     fi
-
+    
     return 0
-
 }
 
 #
@@ -782,9 +814,7 @@ rerun_property_set() {
     (( $# < 2 )) && { 
         rerun_die 'wrong # args: should be: rerun_property_set directory property=value ?property=value?'
     }
-    [[ ! -d $1 ]] && rerun_die "directory not found: $1"
-
-    local -r directory="$1" 
+    local -r directory=$1
     local -a sed_patts=()
     shift ;
     while (( "$#" > 0 ))
@@ -887,13 +917,14 @@ rerun_script_exists() {
 #
 #     rerun_module_path_elements 
 #
-# Arguments: none.
+# Arguments: Colon-separated directory search path.
 #
 rerun_module_path_elements() {
-    (( $# != 0 )) && {
-        rerun_die 'wrong # args: should be: rerun_module_path_elements'
+    (( $# != 1 )) && {
+        rerun_die 'wrong # args: should be: rerun_module_path_elements path'
     }
-    echo "$RERUN_MODULES" | sed ':loop
+    local path=${1}
+    echo "$path" | sed ':loop
 {h
 s/:.*//
 p      
@@ -928,7 +959,7 @@ rerun_module_exists() {
     }
     local -r module="$1"
 
-    for path_element in `rerun_module_path_elements`
+    for path_element in $(rerun_module_path_elements $RERUN_MODULES)
     do
         if [[ -f "$path_element/$module/metadata" ]]
         then
@@ -1134,7 +1165,7 @@ _rerun_man_page() {
         rerun_die "wrong # args: should be: _rerun_man module" 
     }
     local -r module=$1
-    for path_element in `rerun_module_path_elements`
+    for path_element in $(rerun_module_path_elements $RERUN_MODULES)
     do
         if [[ ! -f "$path_element/$module/$module.1" 
                 && -f "$path_element/stubbs/commands/docs/script" ]]
@@ -1173,7 +1204,7 @@ _rerun_module_summary() {
 #
 # Arguments
 # 
-# * directory: Directory containing modules
+# * path: Path to directories containing modules
 #
 # Notes:
 #
@@ -1193,7 +1224,7 @@ _rerun_modules_summary() {
     do
         [[ -f $module/metadata ]] && _rerun_module_summary $module
     done
-    for path_element in `rerun_module_path_elements`
+    for path_element in $(rerun_module_path_elements $RERUN_MODULES)
     do
         if [[ ${RERUN_LOCATION:-} = "${DEFAULT_BINDIR}" 
                 && $path_element != "${DEFAULT_LIBDIR}/rerun/modules" ]]
@@ -1363,7 +1394,7 @@ fi
     rerun_die "RERUN_MODULES is not defined"
 }
 __rerun_module_has_valid_dir__=1
-for path_element in `rerun_module_path_elements`
+for path_element in $(rerun_module_path_elements $RERUN_MODULES)
 do
     if [[ -d "$path_element" ]]
     then

--- a/rerun
+++ b/rerun
@@ -1195,8 +1195,8 @@ _rerun_module_summary() {
     local -r module_name=$(basename "$module_dir")
     local -r module_desc=$(rerun_property_get $module_dir DESCRIPTION)
     local -r module_vers=$(rerun_property_get $module_dir VERSION) || module_vers=""
-    printf "%s%s: \"%s\" - %s\n" "${PAD:-}" \
-        "$(rerun_color bold $module_name)" "${module_desc}" "$module_vers"
+    printf "%s%s: \"%s\" - %s (%s)\n" "${PAD:-}" \
+        "$(rerun_color bold $module_name)" "${module_desc}" "$module_vers" "$module_dir"
     }
 }
 
@@ -1216,16 +1216,15 @@ _rerun_modules_summary() {
     (( $# != 1 )) && { 
         rerun_die "wrong # args: should be: _rerun_modules_summary directory" 
     }
-    local -r directory=$1
     echo $(rerun_color blue "Available modules:")
     shopt -s nullglob # enable
     set +u
-    for module in $directory/*
+    for directory in $(rerun_module_path_elements $1)
     do
-        [[ -f $module/metadata ]] && _rerun_module_summary $module
-    done
-    for path_element in $(rerun_module_path_elements $RERUN_MODULES)
-    do
+        for module in $directory/*
+        do
+            [[ -f $module/metadata ]] && _rerun_module_summary $module
+        done
         if [[ ${RERUN_LOCATION:-} = "${DEFAULT_BINDIR}" 
                 && $path_element != "${DEFAULT_LIBDIR}/rerun/modules" ]]
         then
@@ -1235,7 +1234,6 @@ _rerun_modules_summary() {
             do
                [[ -f $module/metadata ]] && _rerun_module_summary $module
             done
-            break
         fi
     done
     set -u

--- a/rerun
+++ b/rerun
@@ -16,7 +16,7 @@
 
 # The rerun version.
 
-RERUN_VERSION=1.3.5
+RERUN_VERSION=1.3.6
 
 # The default system install directories.
 
@@ -880,6 +880,32 @@ rerun_script_exists() {
 }
 
 #
+# ---
+#
+
+# _rerun_module_path_elements_
+#
+#     rerun_module_path_elements 
+#
+# Arguments: none.
+#
+rerun_module_path_elements() {
+    (( $# != 0 )) && {
+        rerun_die 'wrong # args: should be: rerun_module_path_elements'
+    }
+    echo "$RERUN_MODULES" | sed ':loop
+{h
+s/:.*//
+p      
+g
+s/[^:]*://
+t loop
+d     
+}'
+
+}
+
+#
 # - - -
 #
 
@@ -902,11 +928,14 @@ rerun_module_exists() {
     }
     local -r module="$1"
 
-    if [[ -f "${RERUN_MODULES:-}/$module/metadata" ]]
-    then
-       echo $RERUN_MODULES/$module
-       return 0
-    fi
+    for path_element in `rerun_module_path_elements`
+    do
+        if [[ -f "$path_element/$module/metadata" ]]
+        then
+           echo $path_element/$module
+           return 0
+        fi
+    done
 
     if [[ "${RERUN_LOCATION:-}" = "${DEFAULT_BINDIR}" \
         && -f "${DEFAULT_LIBDIR}/rerun/modules/$module/metadata" ]]
@@ -1105,14 +1134,17 @@ _rerun_man_page() {
         rerun_die "wrong # args: should be: _rerun_man module" 
     }
     local -r module=$1
-    if [[ ! -f "${RERUN_MODULES:-}/$module/$module.1" 
-                && -f "$RERUN_MODULES/stubbs/commands/docs/script" ]]
-    then ${RERUN:-rerun} stubbs:docs --module $module 
-    fi
-    if [[ -f "$RERUN_MODULES/$module/$module.1" ]]
-    then nroff -man "$RERUN_MODULES/$module/$module.1" | ${PAGER:-more}
-    else echo >&2 "Manual could not be generated." 
-    fi
+    for path_element in `rerun_module_path_elements`
+    do
+        if [[ ! -f "$path_element/$module/$module.1" 
+                && -f "$path_element/stubbs/commands/docs/script" ]]
+        then ${RERUN:-rerun} stubbs:docs --module $module 
+        fi
+        if [[ -f "$path_element/$module/$module.1" ]]
+        then nroff -man "$path_element/$module/$module.1" | ${PAGER:-more}
+        else echo >&2 "Manual could not be generated." 
+        fi
+    done
 }
 
 PAD="  "
@@ -1161,16 +1193,20 @@ _rerun_modules_summary() {
     do
         [[ -f $module/metadata ]] && _rerun_module_summary $module
     done
-    if [[ ${RERUN_LOCATION:-} = "${DEFAULT_BINDIR}" 
-                && ${RERUN_MODULES:-} != "${DEFAULT_LIBDIR}/rerun/modules" ]]
-    then
-        echo
-        echo $(rerun_color blue "Available modules in \"${DEFAULT_LIBDIR}/rerun/modules\":")
-        for module in ${DEFAULT_LIBDIR}/rerun/modules/*
-        do
-           [[ -f $module/metadata ]] && _rerun_module_summary $module
-        done
-    fi
+    for path_element in `rerun_module_path_elements`
+    do
+        if [[ ${RERUN_LOCATION:-} = "${DEFAULT_BINDIR}" 
+                && $path_element != "${DEFAULT_LIBDIR}/rerun/modules" ]]
+        then
+            echo
+            echo $(rerun_color blue "Available modules in \"${DEFAULT_LIBDIR}/rerun/modules\":")
+            for module in ${DEFAULT_LIBDIR}/rerun/modules/*
+            do
+               [[ -f $module/metadata ]] && _rerun_module_summary $module
+            done
+            break
+        fi
+    done
     set -u
 }
 
@@ -1321,10 +1357,22 @@ then
 fi
 
 
-# Ensure the modules directory path is defined and is a directory.
+# Ensure the modules directory path is defined and at least one element is a directory.
 #
-[[ -n "${RERUN_MODULES:-}" && -d "${RERUN_MODULES:-}" ]] || {
-    rerun_die "RERUN_MODULES directory not found or does not exist: $RERUN_MODULES"
+[[ -n "${RERUN_MODULES:-}" ]] || {
+    rerun_die "RERUN_MODULES is not defined"
+}
+__rerun_module_has_valid_dir__=1
+for path_element in `rerun_module_path_elements`
+do
+    if [[ -d "$path_element" ]]
+    then
+        __rerun_module_has_valid_dir__=0
+        break
+    fi
+done
+[[ $__rerun_module_has_valid_dir__ = 0 ]] || {
+    rerun_die "RERUN_MODULES does not contain any valid directories: $RERUN_MODULES"
 }
 
 # Clear MODULE and COMMAND in case they were incidentally declared in the environment.

--- a/tests/rerun-1-test.sh
+++ b/tests/rerun-1-test.sh
@@ -50,8 +50,9 @@ it_displays_version_and_license() {
 }
 
 it_displays_modules_when_no_arguments() {
+    . $RERUN
     OUT=$(mktemp "/tmp/rerun.test.XXXXX")
-    make_freddy $RERUN_MODULES
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     rerun > $OUT
     head -1 $OUT | grep -q "Available modules" $OUT
     rm ${OUT}
@@ -67,8 +68,9 @@ it_fails_with_nonexistent_module() {
 
 
 it_displays_command_listing() {
+    . $RERUN
     OUT=$(mktemp "/tmp/rerun.test.XXXXX")
-    make_freddy $RERUN_MODULES
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     rerun freddy > $OUT
     head -1 $OUT | grep -q "Available commands in module"
     grep -q 'dance: "tell freddy to dance"' $OUT
@@ -77,13 +79,15 @@ it_displays_command_listing() {
 }
 
 it_runs_command_without_options() {
-    make_freddy $RERUN_MODULES
+    . $RERUN
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     out=$(rerun freddy:dance)
     test "$out" = "jumps (3)"
 }
 
 it_runs_command_with_option() {
-    make_freddy $RERUN_MODULES
+    . $RERUN
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     out=$(rerun freddy:dance --jumps 5)
     test "$out" = "jumps (5)"
     out=$(rerun freddy:dance -j $$)
@@ -92,8 +96,9 @@ it_runs_command_with_option() {
 
 
 it_runs_command_with_verbosity() {
+    . $RERUN
     OUT=$(mktemp "/tmp/rerun.test.XXXXX")
-    make_freddy $RERUN_MODULES
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     rerun -v freddy:dance 2> $OUT
     grep -q "+ source" $OUT
     grep -q "+ echo 'jumps (3)'" $OUT
@@ -101,8 +106,9 @@ it_runs_command_with_verbosity() {
 }
 
 it_runs_command_with_V_option() {
+    . $RERUN
     OUT=$(mktemp "/tmp/rerun.test.XXXXX")
-    make_freddy $RERUN_MODULES
+    make_freddy $(rerun_module_path_elements $RERUN_MODULES | head -1)
     rerun -V freddy:dance 2> $OUT
     grep -q "+ OPT=freddy:dance" $OUT
     grep -q "+ exit 0" $OUT

--- a/tests/rerun-1-test.sh
+++ b/tests/rerun-1-test.sh
@@ -5,6 +5,7 @@
 # -----------------
 unset RERUN_COLOR
 
+
 # Helpers
 # ------------
 for i in ./functions.sh ../tests/functions.sh `dirname $1`/functions.sh `dirname $0`/functions.sh
@@ -37,15 +38,15 @@ it_displays_help() {
 
 it_displays_usage() {
     usage=$(rerun -help 2>&1 |grep '^usage:')
-    test "$usage" = 'usage: rerun [-h][-v][-V][--version] [-M <dir>] [--answer <file>] [module:[command [options]]]'
+    test "$usage" = 'usage: rerun [-h][-G][-v][-V][--version] [--loglevel <>] [-M <dir>] [--answers|-A <file>] [module:[command [options]]]'
 }
 
 it_displays_version_and_license() {
-    rinfo=( $(rerun -help|grep Version:) )
-    test "${rinfo[1]}" = "Version:"
-    test "${rinfo[2]}" = "1.0.2."
-    test "${rinfo[3]}" = "License:"
-    test "${rinfo[4]}" = "Apache"
+    rinfo=( $(rerun -help 2>&1 | grep Version:) )
+    test "${rinfo[0]}" = "Version:"
+    test "${rinfo[1]}" = "1.3.6."
+    test "${rinfo[2]}" = "License:"
+    test "${rinfo[3]}" = "Apache"
 }
 
 it_displays_modules_when_no_arguments() {

--- a/tests/rerun-2-test.sh
+++ b/tests/rerun-2-test.sh
@@ -29,10 +29,16 @@ describe "rerun(2) Use external module directory"
 it_fails_with_invalid_modules_dir() {
     # Check for expected error message.
     rerun -M /garbage/path 2>&1 | \
-        grep "ERROR: RERUN_MODULES directory not found or does not exist: /garbage/path"
+        grep "ERROR: RERUN_MODULES does not contain any valid directories: /garbage/path"
 }
 
-it_displays_modules_when_no_arguments() {
+it_fails_with_invalid_modules_dir_with_multiple_entries() {
+    # Check for expected error message.
+    rerun -M /garbage/path:/another/garbage/path 2>&1 | \
+        grep "ERROR: RERUN_MODULES does not contain any valid directories: /garbage/path"
+}
+
+it_displays_modules_when_no_arguments_single_path() {
     modules=$(mktemp -d "/tmp/rerun.modules.XXXXX")
     OUT=$modules/out.txt
     make_freddy $modules
@@ -43,7 +49,22 @@ it_displays_modules_when_no_arguments() {
     rmdir ${modules}
 }
 
-it_displays_command_listing() {
+it_displays_modules_when_no_arguments_multiple_paths() {
+    modules1=$(mktemp -d "/tmp/rerun.modules.XXXXX")
+    modules2=$(mktemp -d "/tmp/rerun.modules.XXXXX")
+    OUT=$modules1/out.txt
+    make_freddy $modules1
+    make_freddy $modules2
+    rerun -M $modules1:$modules2 > $OUT
+    head -1 $OUT | grep -q "Available modules" $OUT
+    rm ${OUT}
+    rm -rf ${modules1}/freddy
+    rmdir ${modules1}
+    rm -rf ${modules2}/freddy
+    rmdir ${modules2}
+}
+
+it_displays_command_listing_single_path() {
     modules=$(mktemp -d "/tmp/rerun.modules.XXXXX")
     OUT=$modules/out.txt
     make_freddy $modules
@@ -54,6 +75,29 @@ it_displays_command_listing() {
     rm ${OUT}
     rm -rf ${modules}/freddy
     rmdir ${modules}
+}
+
+it_displays_command_listing_multiple_path() {
+    modules1=$(mktemp -d "/tmp/rerun.modules.XXXXX")
+    modules2=$(mktemp -d "/tmp/rerun.modules.XXXXX")
+    OUT=$modules1/out.txt
+    make_freddy $modules1
+    make_freddy $modules2
+    mv $modules1/freddy $modules1/berrie
+    rerun -M $modules1:$modules2 freddy > $OUT
+    head -1 $OUT | grep -q "Available commands in module"
+    grep -q 'study: "tell freddy to study"' $OUT
+    grep -q '\[ --subject\|-s <math>]: "subject to study"' $OUT
+    rm ${OUT}
+    rerun -M $modules1:$modules2 berrie > $OUT
+    head -1 $OUT | grep -q "Available commands in module"
+    grep -q 'study: "tell freddy to study"' $OUT
+    grep -q '\[ --subject\|-s <math>]: "subject to study"' $OUT
+    rm ${OUT}
+    rm -rf ${modules2}/freddy
+    rmdir ${modules2}
+    rm -rf ${modules1}/berrie
+    rmdir ${modules1}
 }
 
 it_runs_command_without_options() {


### PR DESCRIPTION
This PR adds the ability for `RERUN_MODULES` to contain multiple, colon-separated directory entries, like the `PATH` environment variable.

It adds this support to core rerun, stubbs:, and bash completion.

rerun modules that use `$RERUN_MODULES` where `$RERUN_MODULE_DIR` could be used will need to edit their scripts.