### PR TITLE
Synopsys -> Synopsis in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 rerun - a modular shell automation framework to organize your keeper scripts.
 
-# SYNOPSYS
+# SYNOPSIS
 
 	rerun [-h][-v][-V] [-M <dir>] [--loglevel <>] [module:[command [options]]]
 


### PR DESCRIPTION
I _believe_ (though I could be wrong) that what you wanted to say above the rerun usage is **SYNOPSIS** not SYNOPSYS. Unless you're being clever and I just didn't catch it. :-)