### PR TITLE
GH-233 fix stubbs module failure due to non-bash parent shell propagating to invocation

### DIFF
--- a/rerun
+++ b/rerun
@@ -1027,7 +1027,7 @@ rerun_command_execute() {
     rerun_script_exists "${RERUN_MODULE_DIR:-}" $command || {
         rerun_syntax_error "command not found: \"$module:$command\""
     }
-    local -r RERUN_SHELL=$SHELL
+    local -r RERUN_SHELL=$(which bash)
     local COMMAND_SHELL=$(rerun_property_get "$RERUN_MODULE_DIR" SHELL)
     : ${COMMAND_SHELL:=$RERUN_SHELL}; # default it.
 


### PR DESCRIPTION
this fixes #233 by ensuring RERUN_SHELL is set to a bash shell

```
    local -r RERUN_SHELL=$(which bash)
```

env
```
$ echo $SHELL
/usr/local/bin/zsh
```

command
```
rerun stubbs:add-module -m "example-module" --description "example module which fails"
```
output
```
Created module structure: /Users/username/Documents/dev/rerun/modules/example-module.
```

command
```
$ make check
```
output
```
<snip>
echo "Testing stubbs module..."; \
	if [[ "${PWD}x" = "x" ]]; then export PWD="/Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub"; fi; \
	if [[ "../.." = "/*" ]]; then MYDIR="../.."; else MYDIR="${PWD}/../.."; fi; \
	export RERUN="${MYDIR}/rerun"; \
	export RERUN_MODULES="${MYDIR}/modules"; \
	export LC_ALL="C"; \
	echo "    modules at ${RERUN_MODULES}"; \
	if [ ! -w ${RERUN_MODULES} ]; then \
		CLEANUPDIRS="true"; \
		chmod u+w ${RERUN_MODULES} ${RERUN_MODULES}/stubbs/tests; \
	fi; \
	set -e; \
	${RERUN} stubbs:test --module stubbs; \
	if [[ "${CLEANUPDIRS}" = "true" ]]; then \
		chmod u-w ${RERUN_MODULES} ${RERUN_MODULES}/stubbs/tests; \
	fi
Testing stubbs module...
    modules at /Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub/../../modules
=========================================================
TESTING MODULE: stubbs
=========================================================
add-command
  it_runs_interactively:                           [PASS]
  it_runs_fully_optioned:                          [PASS]
add-module
  it_runs_interactively:                           [PASS]
  it_runs_fully_optioned:                          [PASS]
  it_should_add_module_from_template:              [PASS]
  it_takes_descriptions_w_commas_slashes:          [PASS]
add-option
  it_runs_interactively:                           [PASS]
  it_runs_fully_optioned:                          [PASS]
  it_exports_option_variable:                      [PASS]
  it_does_not_add_duplicate_assignments:           [PASS]
  it_should_not_overquote_descriptions:            [PASS]
  it_fails_when_option_name_contains_whitespace:   [PASS]
  it_quotes_defaults_with_whitespace:              [PASS]
archive
  it_runs_without_options:                         [FAIL]
    + rerun stubbs:archive
    + command /Users/username/Documents/dev/local/rerun/rerun-1.3.8/rerun -M /Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub/../../modules stubbs:archive
    + /Users/username/Documents/dev/local/rerun/rerun-1.3.8/rerun -M /Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub/../../modules stubbs:archive
    Wrote self extracting archive script: /Users/username/Documents/dev/local/rerun/rerun-1.3.8/modules/stubbs/tests/rerun.sh
    + validate rerun.sh
    + archive=rerun.sh
    + test -f rerun.sh
    + file rerun.sh
    + grep bash
    exit code 1
  it_runs_fully_optioned:                          [FAIL]
    + rerun stubbs:archive --file /tmp/rerun.sh.8710 --modules stubbs --version 1.0
    + command /Users/username/Documents/dev/local/rerun/rerun-1.3.8/rerun -M /Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub/../../modules stubbs:archive --file /tmp/rerun.sh.8710 --modules stubbs --version 1.0
    + /Users/username/Documents/dev/local/rerun/rerun-1.3.8/rerun -M /Users/username/Documents/dev/local/rerun/rerun-1.3.8/_build/sub/../../modules stubbs:archive --file /tmp/rerun.sh.8710 --modules stubbs --version 1.0
    ~/Documents/dev/local/rerun/rerun-1.3.8/modules ~/Documents/dev/local/rerun/rerun-1.3.8/modules/stubbs/tests
    Wrote self extracting archive script: /tmp/rerun.sh.8710
    + validate /tmp/rerun.sh.8710
    + archive=/tmp/rerun.sh.8710
    + test -f /tmp/rerun.sh.8710
    + file /tmp/rerun.sh.8710
    + grep bash
    exit code 1
  it_handles_comands_using_quoted_arguments:       [PASS]
  it_builds_the_stubbs_module_rpm:                 [PASS]
  it_builds_a_list_of_rpms:                        [PASS]
  it_builds_a_list_of_debs:                        [PASS]
  it_extracts_only_and_exits:                      [PASS]
  it_runs_from_specified_extract_dir:              [PASS]
  it_runs_archive_from_overridden_TMPDIR:          [PASS]
  it_errors_with_missing_extract_dir_arg:          [PASS]
  it_creates_archive_with_user_template:           [PASS]
docs
  it_runs_interactively:                           [PASS]
  it_runs_fully_optioned:                          [PASS]
functional: functional tests for a bash module
  it_builds_a_functional_module:                   [PASS]
migrate
  it_fails_without_arguments:                      [PASS]
rm-command
  it_prompts_user_for_command:                     [PASS]
  it_removes_specified_command:                    [PASS]
  it_leaves_shared_option_if_other_command_assigned: [PASS]
rm-option
  it_runs_interactively:                           [PASS]
  it_runs_fully_optioned:                          [PASS]
  it_removes_option_after_last_assignment:         [PASS]
  it_retains_option_if_assigned_to_command:        [PASS]
stubbs-functions
  it_performs_stubbs_option_commands:              [PASS]
  it_should_replace_string_in_file:                [PASS]
  it_should_clone_a_module:                        [PASS]
=========================================================
```