### PR TITLE
GH-237 use target module parent dir instead of RERUN_MODULES

### DIFF
--- a/modules/stubbs/commands/rm-option/script
+++ b/modules/stubbs/commands/rm-option/script
@@ -154,8 +154,9 @@ do
     }
     options_parser=$RERUN_MODULE_HOME_DIR/commands/$cmd/$OPTIONS_SCRIPT
     # Generate it
+    RERUN_MODULE_PARENT_DIR="$(dirname $RERUN_MODULE_HOME_DIR)"
     $RERUN_MODULE_DIR/lib/stub/bash/$OPTIONS_GENERATOR \
-        $RERUN_MODULES $MODULE $cmd > $options_parser || rerun_die "Failed generating options parser."
+        $RERUN_MODULE_PARENT_DIR $MODULE $cmd > $options_parser || rerun_die "Failed generating options parser."
     rerun_log info "Wrote options script: $RERUN_MODULE_HOME_DIR/commands/$cmd/options.sh"
     #
     # Update option variable summary in command script.


### PR DESCRIPTION
fixes #237 

`RERUN_MODULES` can contain multiple paths but `generate-options` expects a single directory

This change takes the `RERUN_MODULE_HOME_DIR` which points to the directory of the target module and uses `dirname` to get the next directory up, and uses that in place of `RERUN_MODULES` when passed to `generate-options`.

Seems like some tests surrounding using multiple paths inside RERUN_MODULES would be valuable.