### PR TITLE
GH-239 consistent argument passthrough

### DIFF
--- a/modules/stubbs/lib/stub/bash-pedantic/generate-options
+++ b/modules/stubbs/lib/stub/bash-pedantic/generate-options
@@ -85,11 +85,6 @@ rerun_options_parse() {
 $(for option in $(rerun_options $moddir $module $command); do 
 printf "          %s\n" "$(generate_option_parser $option)"; 
 done)
-            # help option
-            -|--*?)
-                rerun_option_usage
-                exit 2
-                ;;
             # end of options, just arguments left
             *)
               break
@@ -127,4 +122,3 @@ done)
 EOF
 ) 
     # generated to stdout
-

--- a/modules/stubbs/lib/stub/bash/generate-options
+++ b/modules/stubbs/lib/stub/bash/generate-options
@@ -86,11 +86,6 @@ rerun_options_parse() {
 $(for option in $(rerun_options $moddir $module $command); do
 printf "          %s\n" "$(generate_option_parser $option)";
 done)
-            # help option
-            -|--*?) echo >&2 "unrecognized option: \$OPT"
-                rerun_option_usage
-                exit 2
-                ;;
             # end of options, just arguments left
             *)
               break
@@ -132,4 +127,3 @@ done)
 EOF
 )
     # generated to stdout
-


### PR DESCRIPTION
addresses #239 -- removes 'help option' from generate-options to allow **newly generated or updated** module commands to passthrough arguments with double dashes

this means to view the 'help text' for a module command, one should use the `rerun <modulename>:` command

see below for examples of identical output sans for allowing passthrough of double-dash arguments

### creating module
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun stubbs: add-module -m my-module --description "my module"
Created module structure: ./modules/my-module.
```

### creating command
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun stubbs: add-command -m my-module -c my-command --description "my command"
Wrote command script: ./modules/my-module/commands/my-command/script
Wrote options parser: ./modules/my-module/commands/my-command/options.sh
Wrote test script: ./modules/my-module/tests/my-command-1-test.sh
```

### creating option (cannot specify an empty default value on the cmd line -- bug?)
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun stubbs: add-option -m my-module -c my-command -o rerun-option --required true --description "a required rerun option" --export false --default ""
Default:

Wrote option metadata: ./modules/my-module/options/rerun-option/metadata
Updated command metadata:  ./modules/my-module/commands/my-command/metadata
Updated command script header: ./modules/my-module/commands/my-command/script
```

### my-module/commands/my-command/script implementation
```
# Command implementation
# ----------------------

# - - -
echo "wrapped-exe $_CMD_LINE"
# - - -
```

### executing without required argument
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun my-module: my-command
missing required option: --rerun-option
```

### executing with required argument (with value)
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun my-module: my-command --rerun-option blah
wrapped-exe 
```

### executing with required argument (with value), and single-dash passthrough argument
#### before / after change (identical output)
```
$ RERUN_MODULES=./modules rerun my-module: my-command --rerun-option blah -pass-me-through
wrapped-exe -pass-me-through
```

### executing with required argument (with value), and double-dash passthrough argument
#### before change
```
$ RERUN_MODULES=./modules rerun my-module: my-command --rerun-option blah --pass-me-through
unrecognized option: --pass-me-through
usage: rerun my-module:my-command  --rerun-option <> 
```
#### after change
```
$ RERUN_MODULES=./modules rerun my-module: my-command --rerun-option blah --pass-me-through
wrapped-exe --pass-me-through
```