### PR TITLE
GH-249 unify how RERUN_VERSION is grabbed during build and packaging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([rerun], [1.3.8], [rerun-discuss@googlegroups.com],
+AC_INIT([rerun], m4_esyscmd_s([grep ^RERUN_VERSION rerun  | cut -d= -f2]), [rerun-discuss@googlegroups.com],
              [rerun], [https://github.com/rerun/rerun/wiki])
 
 dnl Created by stagr.lee@gmail.com, 27SEP11


### PR DESCRIPTION
This should fix #249 by unifying the behavior of parsing the `RERUN_VERSION` from `rerun` by changing configure.ac to use the same behavior as setup.sh:

```
AC_INIT([rerun], m4_esyscmd_s([grep ^RERUN_VERSION rerun  | cut -d= -f2]), [rerun-discuss@googlegroups.com],
```

Note I initially tried to do this by adding a 'VERSION' file that would be read by rerun, setup.sh, and configure.ac, except that it would require the VERSION file being in the same directory as the rerun file, and with the RPM packaging it appears that would require shoving a file called 'VERSION' in the bin dir (not ideal).

A future enhancement could be to figure out how to do a 'VERSION' file and allow rerun to know its version either by allowing it to source it from a different directory (to be compatible with RPM), or parse the version into the rerun file itself during build/packaging.