### PR TITLE
small cleanup and fixes from #242

### DIFF
--- a/modules/stubbs/commands/add-command/script
+++ b/modules/stubbs/commands/add-command/script
@@ -60,7 +60,7 @@ cat <<EOF
 NAME=$COMMAND
 DESCRIPTION="$DESCRIPTION"
 OPTIONS=
-GENERATE_HELP=$GENERATE_HELP
+GENERATE_HELP="${GENERATE_HELP:-true}"
 EOF
 
 ) > $RERUN_MODULE_HOME_DIR/commands/$COMMAND/metadata || rerun_die "Failed creating command metadata."

--- a/modules/stubbs/commands/add-option/script
+++ b/modules/stubbs/commands/add-option/script
@@ -80,7 +80,6 @@ SHORT=${SHORT:-}
 LONG=${LONG:-$OPTION}
 DEFAULT=$(quote_if_whitespace_string $DEFAULT)
 EXPORT=$EXPORT
-USAGE=${USAGE:-false}
 
 EOF
 ) > $RERUN_MODULE_HOME_DIR/options/$OPTION/metadata || {

--- a/modules/stubbs/lib/stub/bash-pedantic/generate-options
+++ b/modules/stubbs/lib/stub/bash-pedantic/generate-options
@@ -101,8 +101,8 @@ rerun_options_parse() {
     while [ "\$#" -gt 0 ]; do
         OPT="\$1"
         case "\$OPT" in
-$(for option in $(rerun_options $moddir $module $command); do 
-printf "          %s\n" "$(generate_option_parser $option)"; 
+$(for option in $(rerun_options $moddir $module $command); do
+printf "          %s\n" "$(generate_option_parser $option)";
 done)
 $(if [ "$print_help_option" != "false" ]; then generate_help_option; fi)
             # unrecognized arguments

--- a/modules/stubbs/lib/stub/bash/generate-options
+++ b/modules/stubbs/lib/stub/bash/generate-options
@@ -36,12 +36,11 @@ generate_option_parser() {
     argstring=$(printf " --%s" "${optName}" )
   fi
   
-  local USAGE=$(stubbs_option_property $moddir/$module $optName USAGE)
-  if [ "$USAGE" == "true" ]; then
-    printf " %s) rerun_option_usage ;;" "${argstring}"
-  elif [ "$ARGUMENTS" == "false" ]; then
+  if [ "$ARGUMENTS" == "false" ]; then
     # boolean flag. Check if the arg is "true" because the answers population process declares it.
-    printf " %s) %s=true; [[ "\${2:-}" == "true" ]] && shift ;;\n" "${argstring}" "$optVarname"
+    #   if so, shift an extra time
+    #   this means "--myswitch true" will swallow the 'true' value from the command line
+    printf " %s) %s=true; [[ "\${2:-}" == "true" ]] && shift ; shift ;;\n" "${argstring}" "$optVarname"
   else
     printf " %s) rerun_option_check \$# \$1; %s=\$2 ; shift 2 ;;\n" \
     "$argstring" "$optVarname"


### PR DESCRIPTION
Small cleanup from #242 

This removes the USAGE flag that was still getting added to the metadata file for new options, even though we weren't using it anymore.

I also added safety handling around the add-command metadata for 'GENERATE_HELP' to ensure it defaults to true if the value was unspecified.

I also fixed a missed change from #242 where a problem was fixed in the pedantic generate options, but not in the regular one.

This would lead to an endless while loop as an 'argless option' would get processed but never shifted out.